### PR TITLE
feat(blueprint): add apply blueprint cmd

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -1,0 +1,92 @@
+package apply
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fosrl/cli/internal/api"
+	"github.com/fosrl/cli/internal/config"
+	"github.com/fosrl/newt/logger"
+	"github.com/spf13/cobra"
+)
+
+type ApplyBlueprintCmdOpts struct {
+	Name string
+	Path string
+}
+
+func ApplyBlueprintCommand() *cobra.Command {
+	opts := ApplyBlueprintCmdOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply a blueprint",
+		Long:  "Apply a YAML blueprint to the Pangolin server",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return err
+			}
+
+			opts.Path = args[0]
+
+			if _, err := os.Stat(opts.Path); err != nil {
+				return err
+			}
+
+			// Strip file extension and use file basename path as name
+			if opts.Name == "" {
+				filename := filepath.Base(opts.Path)
+				if before, ok := strings.CutSuffix(filename, ".yaml"); ok {
+					opts.Name = before
+				} else if before, ok := strings.CutSuffix(filename, ".yml"); ok {
+					opts.Name = before
+				} else {
+					opts.Name = filename
+				}
+			}
+
+			if len(opts.Name) < 1 || len(opts.Name) > 255 {
+				return errors.New("name must be between 1-255 characters")
+			}
+
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := applyBlueprintMain(cmd, opts); err != nil {
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Name of blueprint (default: filename, without extension)")
+
+	return cmd
+}
+
+func applyBlueprintMain(cmd *cobra.Command, opts ApplyBlueprintCmdOpts) error {
+	api := api.FromContext(cmd.Context())
+	accountStore := config.AccountStoreFromContext(cmd.Context())
+
+	if _, err := accountStore.ActiveAccount(); err != nil {
+		logger.Error("Error: %v", err)
+		return err
+	}
+
+	blueprintContents, err := os.ReadFile(opts.Name)
+	if err != nil {
+		logger.Error("Error: failed to read blueprint file: %v", err)
+		return err
+	}
+
+	_, err = api.ApplyBlueprint(opts.Name, string(blueprintContents))
+	if err != nil {
+		logger.Error("Error: failed to apply blueprint: %v", err)
+		return err
+	}
+
+	logger.Info("Successfully applied blueprint!")
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fosrl/cli/cmd/apply"
 	"github.com/fosrl/cli/cmd/auth"
 	"github.com/fosrl/cli/cmd/auth/login"
 	"github.com/fosrl/cli/cmd/auth/logout"
@@ -41,6 +42,7 @@ func RootCommand(initResources bool) (*cobra.Command, error) {
 	}
 
 	cmd.AddCommand(auth.AuthCommand())
+	cmd.AddCommand(apply.ApplyBlueprintCommand())
 	cmd.AddCommand(selectcmd.SelectCmd())
 	cmd.AddCommand(up.UpCmd())
 	cmd.AddCommand(down.DownCmd())

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -802,3 +802,7 @@ func PollDeviceWebAuth(client *Client, code string) (*DeviceWebAuthPollResponse,
 
 	return &response, message, nil
 }
+
+func (c *Client) ApplyBlueprint(name string, blueprint string) (*ApplyBlueprintResponse, error) {
+	return nil, nil
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -250,9 +250,25 @@ type MyDeviceResponse struct {
 
 // ServerInfo represents server information including version, build type, and license status
 type ServerInfo struct {
-	Version                  string  `json:"version"`
-	SupporterStatusValid     bool    `json:"supporterStatusValid"`
-	Build                    string  `json:"build"` // "oss" | "enterprise" | "saas"
-	EnterpriseLicenseValid   bool    `json:"enterpriseLicenseValid"`
-	EnterpriseLicenseType    *string `json:"enterpriseLicenseType,omitempty"`
+	Version                string  `json:"version"`
+	SupporterStatusValid   bool    `json:"supporterStatusValid"`
+	Build                  string  `json:"build"` // "oss" | "enterprise" | "saas"
+	EnterpriseLicenseValid bool    `json:"enterpriseLicenseValid"`
+	EnterpriseLicenseType  *string `json:"enterpriseLicenseType,omitempty"`
+}
+
+// ApplyBlueprintRequest represents a new blueprint application request.
+type ApplyBlueprintRequest struct {
+	Name      string `json:"name"`
+	Blueprint string `json:"blueprint"`
+}
+
+type ApplyBlueprintResponse struct {
+	Name        string  `json:"name"`
+	OrgID       string  `json:"orgId"`
+	Source      string  `json:"source"`
+	Message     *string `json:"message"`
+	BlueprintID string  `json:"blueprintId"`
+	Succeeded   bool    `json:"succeeded"`
+	Contents    string  `json:"contents"`
 }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This adds an `apply` subcommand that is able to apply Pangolin blueprints to an existing configuration. 

## How to test?

Run `pangolin apply` on a blueprint in an org where you have access to apply blueprints.
