### PR TITLE
feat: clean up stale DNS after unclean tunnel shutdown

### DIFF
--- a/cmd/cleanup/cleanup_unix.go
+++ b/cmd/cleanup/cleanup_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package cleanup
+
+import (
+	"errors"
+	"os"
+	"runtime"
+
+	"github.com/fosrl/cli/internal/logger"
+	"github.com/fosrl/cli/internal/olmdns"
+	"github.com/spf13/cobra"
+)
+
+func CleanupCmd() *cobra.Command {
+	interfaceName := olmdns.DefaultInterfaceName
+
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Clean up stale DNS configuration",
+		Long: `Remove stale DNS configuration left from an unclean shutdown.
+
+This is useful if the client was killed while a tunnel was active and system DNS
+was not restored. The same cleanup runs automatically before starting a connection.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runtime.GOOS != "windows" && os.Geteuid() != 0 {
+				return errors.New("elevated permissions are required to clean up DNS configuration")
+			}
+
+			if err := olmdns.CleanupStaleState(interfaceName); err != nil {
+				logger.Error("Failed to clean up stale DNS configuration: %v", err)
+				return err
+			}
+
+			logger.Success("Stale DNS configuration cleaned up")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&interfaceName, "interface-name", olmdns.DefaultInterfaceName, "WireGuard interface `name` used when the tunnel was active")
+
+	return cmd
+}

--- a/cmd/cleanup/cleanup_windows.go
+++ b/cmd/cleanup/cleanup_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cleanup
+
+import "github.com/spf13/cobra"
+
+func CleanupCmd() *cobra.Command {
+	return nil
+}

--- a/cmd/down/client/client.go
+++ b/cmd/down/client/client.go
@@ -6,27 +6,32 @@ import (
 
 	"github.com/fosrl/cli/internal/config"
 	"github.com/fosrl/cli/internal/logger"
+	"github.com/fosrl/cli/internal/olmdns"
 	"github.com/fosrl/cli/internal/olm"
 	"github.com/fosrl/cli/internal/tui"
 	"github.com/spf13/cobra"
 )
 
 func ClientDownCmd() *cobra.Command {
+	interfaceName := olmdns.DefaultInterfaceName
+
 	cmd := &cobra.Command{
 		Use:   "client",
 		Short: "Stop the client connection",
 		Long:  "Stop the currently running client connection",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := clientDownMain(cmd); err != nil {
+			if err := clientDownMain(cmd, interfaceName); err != nil {
 				os.Exit(1)
 			}
 		},
 	}
 
+	cmd.Flags().StringVar(&interfaceName, "interface-name", olmdns.DefaultInterfaceName, "WireGuard interface `name` used when the tunnel was active")
+
 	return cmd
 }
 
-func clientDownMain(cmd *cobra.Command) error {
+func clientDownMain(cmd *cobra.Command, interfaceName string) error {
 	cfg := config.ConfigFromContext(cmd.Context())
 
 	// Get socket path from config or use default
@@ -86,6 +91,10 @@ func clientDownMain(cmd *cobra.Command) error {
 		logger.Success("Client shutdown completed")
 	} else {
 		logger.Info("Client shutdown initiated: %s", exitResp.Status)
+	}
+
+	if err := olmdns.CleanupStaleState(interfaceName); err != nil {
+		logger.Warning("Failed to clean up stale DNS configuration: %v", err)
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fosrl/cli/cmd/auth/login"
 	"github.com/fosrl/cli/cmd/auth/logout"
 	"github.com/fosrl/cli/cmd/authdaemon"
+	"github.com/fosrl/cli/cmd/cleanup"
 	"github.com/fosrl/cli/cmd/down"
 	"github.com/fosrl/cli/cmd/list"
 	"github.com/fosrl/cli/cmd/logs"
@@ -59,6 +60,9 @@ func RootCommand(initResources bool) (*cobra.Command, error) {
 	}
 	if downCmd := down.DownCmd(); downCmd != nil {
 		cmd.AddCommand(downCmd)
+	}
+	if cleanupCmd := cleanup.CleanupCmd(); cleanupCmd != nil {
+		cmd.AddCommand(cleanupCmd)
 	}
 	if logsCmd := logs.LogsCmd(); logsCmd != nil {
 		cmd.AddCommand(logsCmd)

--- a/cmd/up/client/client.go
+++ b/cmd/up/client/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fosrl/cli/internal/config"
 	"github.com/fosrl/cli/internal/fingerprint"
 	"github.com/fosrl/cli/internal/logger"
+	"github.com/fosrl/cli/internal/olmdns"
 	"github.com/fosrl/cli/internal/olm"
 	"github.com/fosrl/cli/internal/tui"
 	"github.com/fosrl/cli/internal/utils"
@@ -601,6 +602,11 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 			logger.Info("Please run with sudo or use detached mode (default) to run the subprocess elevated.")
 			return err
 		}
+	}
+
+	// Clean up DNS left from an unclean shutdown before any network operations.
+	if err := olmdns.CleanupStaleState(opts.InterfaceName); err != nil {
+		logger.Warning("Failed to clean up stale DNS configuration: %v", err)
 	}
 
 	olm, err := olmpkg.Init(ctx, olmInitConfig)

--- a/internal/olmdns/cleanup.go
+++ b/internal/olmdns/cleanup.go
@@ -1,0 +1,16 @@
+package olmdns
+
+import (
+	override "github.com/fosrl/olm/dns/override"
+)
+
+const DefaultInterfaceName = "pangolin"
+
+// CleanupStaleState removes DNS configuration left from an unclean shutdown
+// (for example, killing the process while the tunnel was active).
+func CleanupStaleState(interfaceName string) error {
+	if interfaceName == "" {
+		interfaceName = DefaultInterfaceName
+	}
+	return override.CleanupStaleState(interfaceName)
+}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Wire olm's CleanupStaleState into up, down, and a new cleanup command so leftover DNS configuration is removed when the client did not shut down cleanly.

## How to test?

Bring the cli up and kill the background process, using up/down/cleanup should not attempt to fix the stale configuration.

