### PR TITLE
fix(auth): suppress browser output during login #25

### DIFF
--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -97,15 +97,6 @@ func loginWithWeb(hostname string) (string, error) {
 		_, err := reader.ReadString('\n')
 		if err == nil {
 			// User pressed Enter, open browser
-			oldStdout := browser.Stdout
-			oldStderr := browser.Stderr
-			browser.Stdout = io.Discard
-			browser.Stderr = io.Discard
-			defer func() {
-				browser.Stdout = oldStdout
-				browser.Stderr = oldStderr
-			}()
-
 			if err := openBrowserQuietly(loginURL); err != nil {
 				// Don't fail if browser can't be opened, just warn
 				logger.Warning("Failed to open browser automatically")

--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -34,6 +34,21 @@ func getDeviceName() string {
 	return hostname
 }
 
+func openBrowserQuietly(url string) error {
+	stdout := browser.Stdout
+	stderr := browser.Stderr
+
+	browser.Stdout = io.Discard
+	browser.Stderr = io.Discard
+
+	defer func() {
+		browser.Stdout = stdout
+		browser.Stderr = stderr
+	}()
+
+	return browser.OpenURL(url)
+}
+
 func loginWithWeb(hostname string) (string, error) {
 	// Build base URL for login (use hostname as-is, StartDeviceWebAuth will add /api/v1)
 	baseURL := hostname
@@ -91,7 +106,7 @@ func loginWithWeb(hostname string) (string, error) {
 				browser.Stderr = oldStderr
 			}()
 
-			if err := browser.OpenURL(loginURL); err != nil {
+			if err := openBrowserQuietly(loginURL); err != nil {
 				// Don't fail if browser can't be opened, just warn
 				logger.Warning("Failed to open browser automatically")
 				logger.Info("Please manually visit: %s", baseLoginURL)

--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -81,6 +82,15 @@ func loginWithWeb(hostname string) (string, error) {
 		_, err := reader.ReadString('\n')
 		if err == nil {
 			// User pressed Enter, open browser
+			oldStdout := browser.Stdout
+			oldStderr := browser.Stderr
+			browser.Stdout = io.Discard
+			browser.Stderr = io.Discard
+			defer func() {
+				browser.Stdout = oldStdout
+				browser.Stderr = oldStderr
+			}()
+
 			if err := browser.OpenURL(loginURL); err != nil {
 				// Don't fail if browser can't be opened, just warn
 				logger.Warning("Failed to open browser automatically")
@@ -328,11 +338,11 @@ func loginMain(cmd *cobra.Command, opts *LoginCmdOpts) error {
 	} else if apiServerInfo != nil {
 		// Convert api.ServerInfo to config.ServerInfo
 		serverInfo := &config.ServerInfo{
-			Version:                  apiServerInfo.Version,
-			SupporterStatusValid:     apiServerInfo.SupporterStatusValid,
-			Build:                    apiServerInfo.Build,
-			EnterpriseLicenseValid:   apiServerInfo.EnterpriseLicenseValid,
-			EnterpriseLicenseType:    apiServerInfo.EnterpriseLicenseType,
+			Version:                apiServerInfo.Version,
+			SupporterStatusValid:   apiServerInfo.SupporterStatusValid,
+			Build:                  apiServerInfo.Build,
+			EnterpriseLicenseValid: apiServerInfo.EnterpriseLicenseValid,
+			EnterpriseLicenseType:  apiServerInfo.EnterpriseLicenseType,
 		}
 		// Update account with server info
 		account := accountStore.Accounts[user.UserID]


### PR DESCRIPTION
## Fixes #25.

This PR suppresses stdout/stderr from the browser launcher during the authentication login browser-open step.

The reported issue shows Chromium/Wayland-specific warnings being printed to the terminal even though the login succeeds. Since `pkg/browser` forwards the launched browser process's stdout and stderr to the CLI, this change temporarily redirects those streams to `io.Discard` while opening the browser, preventing browser-specific output from appearing during the login flow.

## How to test

* Built successfully using `go build -o cli .`
* Ran `go test ./...`
* Verified the browser still opens normally during the login flow.
* Verified `xdg-open` launches the default browser successfully.
* Tested in a Wayland environment (`WAYLAND_DISPLAY=wayland-0`).

I wasn't able to reproduce the original Chromium/Wayland warnings because my Linux environment uses Firefox as the default browser. This implementation is based on the observation that `pkg/browser` forwards the browser launcher's stdout/stderr to the CLI. If this doesn't resolve the issue in the original Chromium-based environment, I'm happy to investigate an alternative approach.
