### PR TITLE
0.15.0

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -134,6 +134,9 @@ func dumpConfig(cfg *config.Config) error {
 	if cfg.IsSet("up.upstream_dns") {
 		up["upstream_dns"] = cfg.GetStringSlice("up.upstream_dns")
 	}
+	if cfg.IsSet("up.prefer_local_routes") {
+		up["prefer_local_routes"] = cfg.GetBool("up.prefer_local_routes")
+	}
 	if len(up) > 0 {
 		out["up"] = up
 	}

--- a/cmd/status/client/client.go
+++ b/cmd/status/client/client.go
@@ -90,7 +90,7 @@ func printStatusTable(status *olm.StatusResponse) {
 	// Print peers if there are any
 	if len(status.PeerStatuses) > 0 {
 		fmt.Println("")
-		peerHeaders := []string{"SITE", "ENDPOINT", "STATUS", "LAST SEEN", "RELAY"}
+		peerHeaders := []string{"SITE", "ENDPOINT", "STATUS", "LAST SEEN", "CONNECTION"}
 		peerRows := [][]string{}
 
 		for _, peer := range status.PeerStatuses {
@@ -101,13 +101,27 @@ func printStatusTable(status *olm.StatusResponse) {
 				peer.Endpoint,
 				formatStatus(peer.Connected, true), // Peers don't have registered field, use true
 				lastSeen,
-				fmt.Sprintf("%t", peer.IsRelay),
+				formatConnectionMode(peer.IsLocal, peer.IsRelay),
 			})
 
 		}
 		utils.PrintTable(peerHeaders, peerRows)
 	} else {
 		fmt.Println("\nNo peers connected")
+	}
+}
+
+// formatConnectionMode summarizes how a peer is currently connected. Local and relay are
+// mutually exclusive; when neither applies the peer is connected directly to its public
+// endpoint.
+func formatConnectionMode(isLocal, isRelay bool) string {
+	switch {
+	case isLocal:
+		return "Local"
+	case isRelay:
+		return "Relay"
+	default:
+		return "Direct"
 	}
 }
 

--- a/cmd/up/client/client.go
+++ b/cmd/up/client/client.go
@@ -167,8 +167,8 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 	// explicitly passed. Resolved here (rather than left to the subprocess,
 	// which runs as root and may not have access to the user's config) so it
 	// can be forwarded to the subprocess unconditionally below.
-	if !cmd.Flags().Changed("match-domains") && len(cfg.MatchDomains) > 0 {
-		opts.MatchDomains = cfg.MatchDomains
+	if !cmd.Flags().Changed("match-domains") && cfg.IsSet("up.match_domains") {
+		opts.MatchDomains = cfg.GetStringSlice("up.match_domains")
 	}
 
 	if runtime.GOOS == "windows" {

--- a/cmd/up/client/client.go
+++ b/cmd/up/client/client.go
@@ -167,8 +167,8 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 	// explicitly passed. Resolved here (rather than left to the subprocess,
 	// which runs as root and may not have access to the user's config) so it
 	// can be forwarded to the subprocess unconditionally below.
-	if !cmd.Flags().Changed("match-domains") && cfg.IsSet("up.match_domains") {
-		opts.MatchDomains = cfg.GetStringSlice("up.match_domains")
+	if !cmd.Flags().Changed("match-domains") && cfg.IsSet("up.match_domains_dns") {
+		opts.MatchDomains = cfg.GetStringSlice("up.match_domains_dns")
 	}
 
 	if runtime.GOOS == "windows" {

--- a/cmd/up/client/client.go
+++ b/cmd/up/client/client.go
@@ -35,25 +35,26 @@ const (
 )
 
 type ClientUpCmdOpts struct {
-	ID            string
-	Secret        string
-	Endpoint      string
-	OrgID         string
-	MTU           int
-	DNS           string
-	InterfaceName string
-	LogLevel      string
-	HTTPAddr      string
-	PingInterval  time.Duration
-	PingTimeout   time.Duration
-	Holepunch     bool
-	TlsClientCert string
-	Attached      bool
-	Silent        bool
-	OverrideDNS   bool
-	TunnelDNS     bool
-	UpstreamDNS   []string
-	MatchDomains  []string
+	ID                string
+	Secret            string
+	Endpoint          string
+	OrgID             string
+	MTU               int
+	DNS               string
+	InterfaceName     string
+	LogLevel          string
+	HTTPAddr          string
+	PingInterval      time.Duration
+	PingTimeout       time.Duration
+	Holepunch         bool
+	TlsClientCert     string
+	Attached          bool
+	Silent            bool
+	OverrideDNS       bool
+	TunnelDNS         bool
+	UpstreamDNS       []string
+	MatchDomains      []string
+	PreferLocalRoutes bool
 }
 
 // validateDNSIP ensures the given DNS server string is a valid IP address.
@@ -135,6 +136,7 @@ func ClientUpCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.TunnelDNS, "tunnel-dns", false, "When enabled, DNS queries are routed through the tunnel for remote resolution. To ensure queries are tunneled correctly, you must define the DNS server as a Pangolin resource and enter its address as an Upstream DNS Server.")
 	cmd.Flags().StringSliceVar(&opts.UpstreamDNS, "upstream-dns", []string{}, "List of DNS servers to use for external DNS resolution if overriding system DNS")
 	cmd.Flags().StringSliceVar(&opts.MatchDomains, "match-domains", nil, "FQDN wildcard patterns (e.g. '*.proxy.internal') to check against local records/upstream DNS; queries for non-matching domains go directly to the system's DNS servers (default: match all domains, or the value from config if set)")
+	cmd.Flags().BoolVar(&opts.PreferLocalRoutes, "prefer-local-routes", false, "Add tunnel routes with a high metric so overlapping local/connected routes take precedence (default false)")
 	cmd.Flags().BoolVar(&opts.Attached, "attach", false, "Run in attached (foreground) mode, (default: detached (background) mode)")
 	cmd.Flags().BoolVar(&opts.Silent, "silent", false, "Disable TUI and run silently when detached")
 
@@ -155,6 +157,9 @@ func applyUpDefaults(cmd *cobra.Command, opts *ClientUpCmdOpts, cfg *config.Conf
 	}
 	if !cmd.Flags().Changed("upstream-dns") && cfg.IsSet("up.upstream_dns") {
 		opts.UpstreamDNS = cfg.GetStringSlice("up.upstream_dns")
+	}
+	if !cmd.Flags().Changed("prefer-local-routes") && cfg.IsSet("up.prefer_local_routes") {
+		opts.PreferLocalRoutes = cfg.GetBool("up.prefer_local_routes")
 	}
 }
 
@@ -381,6 +386,11 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 			// come from the persisted config rather than the flag, and the
 			// subprocess (running as root) may not have access to that config.
 			cmdArgs = append(cmdArgs, "--match-domains", strings.Join(opts.MatchDomains, ","))
+		}
+		if opts.PreferLocalRoutes {
+			// Always forwarded when true (rather than gated on Changed) for the
+			// same reason as MatchDomains above - it may have come from config.
+			cmdArgs = append(cmdArgs, "--prefer-local-routes")
 		}
 
 		// Add positional args if any
@@ -622,6 +632,7 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 		TunnelDNS:            opts.TunnelDNS,
 		UpstreamDNS:          upstreamDNS,
 		MatchDomains:         opts.MatchDomains,
+		PreferLocalRoutes:    opts.PreferLocalRoutes,
 		UserToken:            userToken,
 		InitialFingerprint:   initialFingerprint,
 		InitialPostures:      initialPostures,

--- a/cmd/up/client/client.go
+++ b/cmd/up/client/client.go
@@ -53,6 +53,7 @@ type ClientUpCmdOpts struct {
 	OverrideDNS   bool
 	TunnelDNS     bool
 	UpstreamDNS   []string
+	MatchDomains  []string
 }
 
 // validateDNSIP ensures the given DNS server string is a valid IP address.
@@ -133,6 +134,7 @@ func ClientUpCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.OverrideDNS, "override-dns", true, "When enabled, the client uses custom DNS servers to resolve internal resources and aliases. This overrides your system's default DNS settings. Queries that cannot be resolved as a Pangolin resource will be forwarded to your configured Upstream DNS Server.")
 	cmd.Flags().BoolVar(&opts.TunnelDNS, "tunnel-dns", false, "When enabled, DNS queries are routed through the tunnel for remote resolution. To ensure queries are tunneled correctly, you must define the DNS server as a Pangolin resource and enter its address as an Upstream DNS Server.")
 	cmd.Flags().StringSliceVar(&opts.UpstreamDNS, "upstream-dns", []string{}, "List of DNS servers to use for external DNS resolution if overriding system DNS")
+	cmd.Flags().StringSliceVar(&opts.MatchDomains, "match-domains", nil, "FQDN wildcard patterns (e.g. '*.proxy.internal') to check against local records/upstream DNS; queries for non-matching domains go directly to the system's DNS servers (default: match all domains, or the value from config if set)")
 	cmd.Flags().BoolVar(&opts.Attached, "attach", false, "Run in attached (foreground) mode, (default: detached (background) mode)")
 	cmd.Flags().BoolVar(&opts.Silent, "silent", false, "Disable TUI and run silently when detached")
 
@@ -160,6 +162,14 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 	apiClient := api.FromContext(cmd.Context())
 	accountStore := config.AccountStoreFromContext(cmd.Context())
 	cfg := config.ConfigFromContext(cmd.Context())
+
+	// Fall back to the persisted config value when --match-domains wasn't
+	// explicitly passed. Resolved here (rather than left to the subprocess,
+	// which runs as root and may not have access to the user's config) so it
+	// can be forwarded to the subprocess unconditionally below.
+	if !cmd.Flags().Changed("match-domains") && len(cfg.MatchDomains) > 0 {
+		opts.MatchDomains = cfg.MatchDomains
+	}
 
 	if runtime.GOOS == "windows" {
 		err := errors.New("this command is currently unsupported on Windows")
@@ -365,6 +375,12 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 		if cmd.Flags().Changed("upstream-dns") {
 			// Comma sep
 			cmdArgs = append(cmdArgs, "--upstream-dns", strings.Join(opts.UpstreamDNS, ","))
+		}
+		if len(opts.MatchDomains) > 0 {
+			// Always forwarded (rather than gated on Changed) since it may have
+			// come from the persisted config rather than the flag, and the
+			// subprocess (running as root) may not have access to that config.
+			cmdArgs = append(cmdArgs, "--match-domains", strings.Join(opts.MatchDomains, ","))
 		}
 
 		// Add positional args if any
@@ -605,6 +621,7 @@ func clientUpMain(cmd *cobra.Command, opts *ClientUpCmdOpts, extraArgs []string)
 		OverrideDNS:          opts.OverrideDNS,
 		TunnelDNS:            opts.TunnelDNS,
 		UpstreamDNS:          upstreamDNS,
+		MatchDomains:         opts.MatchDomains,
 		UserToken:            userToken,
 		InitialFingerprint:   initialFingerprint,
 		InitialPostures:      initialPostures,

--- a/go.mod
+++ b/go.mod
@@ -78,5 +78,6 @@ require (
 // If changes to Olm or Newt are required, use these
 // replace directives during development.
 //
-// replace github.com/fosrl/olm => ../olm
-// replace github.com/fosrl/newt => ../newt
+replace github.com/fosrl/olm => ../olm
+
+replace github.com/fosrl/newt => ../newt

--- a/go.sum
+++ b/go.sum
@@ -50,10 +50,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/fosrl/newt v1.14.0 h1:9jpyfCNAtsH7rPojyIGJwqOqnLZdxm8b+njY5ZuY/6c=
-github.com/fosrl/newt v1.14.0/go.mod h1:l6kWoZPSaXT+ZRUjiyPgwflRqZWYaXpUj9oQ0sOPh4o=
-github.com/fosrl/olm v1.7.0 h1:Om/wXKNcbNz1hN46olKrkwQd3bUknzqP2qxCYPDEyXI=
-github.com/fosrl/olm v1.7.0/go.mod h1:6TXwb4EXb1DfqB3Ks2QPZotsOtg+aJsa/t4VWaMIPHI=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,13 @@ type UpConfig struct {
 	// --match-domains flag when the flag isn't passed explicitly. Empty means
 	// match every domain (the feature is disabled).
 	MatchDomains []string `mapstructure:"match_domains_dns" json:"match_domains_dns"`
+
+	// PreferLocalRoutes, when enabled, adds tunnel routes with a high metric so
+	// overlapping local/connected routes take precedence over the VPN route to
+	// the same destination. Used as the default for `pangolin up`'s
+	// --prefer-local-routes flag when the flag isn't passed explicitly.
+	// Defaults to false.
+	PreferLocalRoutes *bool `mapstructure:"prefer_local_routes" json:"prefer_local_routes,omitempty"`
 }
 
 // CompanionAppDataDirs holds per-platform overrides for the desktop app data directory.
@@ -57,6 +64,7 @@ var ConfigOptions = []string{
 	"up.upstream_dns",
 	"up.override_dns",
 	"up.match_domains_dns",
+	"up.prefer_local_routes",
 }
 
 // SupportedConfigKeys returns the settable config keys.
@@ -236,6 +244,13 @@ func (c *Config) SetKey(key, value string) error {
 		domains := splitCommaList(value)
 		c.Up.MatchDomains = domains
 		c.v.Set(key, domains)
+	case "up.prefer_local_routes":
+		b, err := parseBool(value)
+		if err != nil {
+			return err
+		}
+		c.Up.PreferLocalRoutes = &b
+		c.v.Set(key, b)
 	default:
 		return fmt.Errorf("unknown config key %q; supported keys: %s", key, strings.Join(SupportedConfigKeys(), ", "))
 	}
@@ -273,6 +288,11 @@ func (c *Config) GetKey(key string) (string, error) {
 			return "", errConfigKeyUnset(key)
 		}
 		return strings.Join(c.GetStringSlice(key), ","), nil
+	case "up.prefer_local_routes":
+		if !c.IsSet(key) {
+			return "", errConfigKeyUnset(key)
+		}
+		return fmt.Sprintf("%t", c.GetBool(key)), nil
 	default:
 		return "", fmt.Errorf("unknown config key %q; supported keys: %s", key, strings.Join(SupportedConfigKeys(), ", "))
 	}
@@ -325,6 +345,9 @@ func (c *Config) Save() error {
 	}
 	if c.Up.MatchDomains != nil {
 		c.v.Set("up.match_domains_dns", c.Up.MatchDomains)
+	}
+	if c.Up.PreferLocalRoutes != nil {
+		c.v.Set("up.prefer_local_routes", *c.Up.PreferLocalRoutes)
 	}
 
 	dir, err := GetPangolinConfigDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ var ConfigOptions = []string{
 	"up.tunnel_dns",
 	"up.upstream_dns",
 	"up.override_dns",
+	"up.match_domains",
 }
 
 // SupportedConfigKeys returns the settable config keys.
@@ -106,7 +107,7 @@ func newConfigViper() (*viper.Viper, error) {
 	v.SetDefault("disable_update_check", false)
 	v.SetDefault("disable_companion_mode", false)
 	v.SetDefault("companion_app_data_dirs", map[string]string{})
-	v.SetDefault("match_domains", []string{})
+	v.SetDefault("up.match_domains", []string{})
 
 	return v, nil
 }
@@ -231,6 +232,10 @@ func (c *Config) SetKey(key, value string) error {
 		servers := splitCommaList(value)
 		c.Up.UpstreamDNS = servers
 		c.v.Set(key, servers)
+	case "up.match_domains":
+		domains := splitCommaList(value)
+		c.Up.MatchDomains = domains
+		c.v.Set(key, domains)
 	default:
 		return fmt.Errorf("unknown config key %q; supported keys: %s", key, strings.Join(SupportedConfigKeys(), ", "))
 	}
@@ -259,6 +264,11 @@ func (c *Config) GetKey(key string) (string, error) {
 		}
 		return fmt.Sprintf("%t", c.GetBool(key)), nil
 	case "up.upstream_dns":
+		if !c.IsSet(key) {
+			return "", errConfigKeyUnset(key)
+		}
+		return strings.Join(c.GetStringSlice(key), ","), nil
+	case "up.match_domains":
 		if !c.IsSet(key) {
 			return "", errConfigKeyUnset(key)
 		}
@@ -301,7 +311,6 @@ func (c *Config) Save() error {
 	c.v.Set("disable_update_check", c.DisableUpdateCheck)
 	c.v.Set("disable_companion_mode", c.DisableCompanionMode)
 	c.v.Set("companion_app_data_dirs", c.CompanionAppDataDirs)
-	c.v.Set("match_domains", c.Up.MatchDomains)
 
 	// Only persist up keys that were explicitly set so we do not write
 	// zero-value bools that would later look like intentional overrides.
@@ -313,6 +322,9 @@ func (c *Config) Save() error {
 	}
 	if c.Up.UpstreamDNS != nil {
 		c.v.Set("up.upstream_dns", c.Up.UpstreamDNS)
+	}
+	if c.Up.MatchDomains != nil {
+		c.v.Set("up.match_domains", c.Up.MatchDomains)
 	}
 
 	dir, err := GetPangolinConfigDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,14 @@ type UpConfig struct {
 	TunnelDNS   *bool    `mapstructure:"tunnel_dns" json:"tunnel_dns,omitempty"`
 	UpstreamDNS []string `mapstructure:"upstream_dns" json:"upstream_dns,omitempty"`
 	OverrideDNS *bool    `mapstructure:"override_dns" json:"override_dns,omitempty"`
+
+	// MatchDomains lists FQDN wildcard patterns (using * and ? wildcards, e.g.
+	// "*.proxy.internal") that olm should check against local records/upstream
+	// DNS. Queries for domains that don't match any pattern are sent directly to
+	// the host's system DNS servers. Used as the default for `pangolin up`'s
+	// --match-domains flag when the flag isn't passed explicitly. Empty means
+	// match every domain (the feature is disabled).
+	MatchDomains []string `mapstructure:"match_domains" json:"match_domains"`
 }
 
 // CompanionAppDataDirs holds per-platform overrides for the desktop app data directory.
@@ -98,6 +106,7 @@ func newConfigViper() (*viper.Viper, error) {
 	v.SetDefault("disable_update_check", false)
 	v.SetDefault("disable_companion_mode", false)
 	v.SetDefault("companion_app_data_dirs", map[string]string{})
+	v.SetDefault("match_domains", []string{})
 
 	return v, nil
 }
@@ -292,6 +301,7 @@ func (c *Config) Save() error {
 	c.v.Set("disable_update_check", c.DisableUpdateCheck)
 	c.v.Set("disable_companion_mode", c.DisableCompanionMode)
 	c.v.Set("companion_app_data_dirs", c.CompanionAppDataDirs)
+	c.v.Set("match_domains", c.Up.MatchDomains)
 
 	// Only persist up keys that were explicitly set so we do not write
 	// zero-value bools that would later look like intentional overrides.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ type UpConfig struct {
 	// the host's system DNS servers. Used as the default for `pangolin up`'s
 	// --match-domains flag when the flag isn't passed explicitly. Empty means
 	// match every domain (the feature is disabled).
-	MatchDomains []string `mapstructure:"match_domains" json:"match_domains"`
+	MatchDomains []string `mapstructure:"match_domains_dns" json:"match_domains_dns"`
 }
 
 // CompanionAppDataDirs holds per-platform overrides for the desktop app data directory.
@@ -56,7 +56,7 @@ var ConfigOptions = []string{
 	"up.tunnel_dns",
 	"up.upstream_dns",
 	"up.override_dns",
-	"up.match_domains",
+	"up.match_domains_dns",
 }
 
 // SupportedConfigKeys returns the settable config keys.
@@ -107,7 +107,7 @@ func newConfigViper() (*viper.Viper, error) {
 	v.SetDefault("disable_update_check", false)
 	v.SetDefault("disable_companion_mode", false)
 	v.SetDefault("companion_app_data_dirs", map[string]string{})
-	v.SetDefault("up.match_domains", []string{})
+	v.SetDefault("up.match_domains_dns", []string{})
 
 	return v, nil
 }
@@ -232,7 +232,7 @@ func (c *Config) SetKey(key, value string) error {
 		servers := splitCommaList(value)
 		c.Up.UpstreamDNS = servers
 		c.v.Set(key, servers)
-	case "up.match_domains":
+	case "up.match_domains_dns":
 		domains := splitCommaList(value)
 		c.Up.MatchDomains = domains
 		c.v.Set(key, domains)
@@ -268,7 +268,7 @@ func (c *Config) GetKey(key string) (string, error) {
 			return "", errConfigKeyUnset(key)
 		}
 		return strings.Join(c.GetStringSlice(key), ","), nil
-	case "up.match_domains":
+	case "up.match_domains_dns":
 		if !c.IsSet(key) {
 			return "", errConfigKeyUnset(key)
 		}
@@ -324,7 +324,7 @@ func (c *Config) Save() error {
 		c.v.Set("up.upstream_dns", c.Up.UpstreamDNS)
 	}
 	if c.Up.MatchDomains != nil {
-		c.v.Set("up.match_domains", c.Up.MatchDomains)
+		c.v.Set("up.match_domains_dns", c.Up.MatchDomains)
 	}
 
 	dir, err := GetPangolinConfigDir()

--- a/internal/olm/client.go
+++ b/internal/olm/client.go
@@ -47,6 +47,7 @@ type OLMPeerStatus struct {
 	LastSeen  time.Time     `json:"lastSeen"`
 	Endpoint  string        `json:"endpoint,omitempty"`
 	IsRelay   bool          `json:"isRelay"`
+	IsLocal   bool          `json:"isLocal"` // true when connected via a local network endpoint, bypassing both the public endpoint and relay
 	PeerIP    string        `json:"peerAddress,omitempty"`
 }
 


### PR DESCRIPTION
- Add direct connections to sites when on the same network instead of relaying
- Add `match_domains_dns` to match specific domains before sending to an upstream DNS server
- Add `prefer_local_routes` option to prefer local routes over VPN routes
- Fix don't remove non-controlled routes