### PR TITLE
feat: add ManagedBy build flag to disable auto-updates

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,7 +112,7 @@ func newConfigViper() (*viper.Viper, error) {
 	// Defaults
 	v.SetDefault("log_level", "info")
 	v.SetDefault("log_file", defaultLogPath)
-	v.SetDefault("disable_update_check", false)
+	v.SetDefault("disable_update_check", IsExternallyManaged())
 	v.SetDefault("disable_companion_mode", false)
 	v.SetDefault("companion_app_data_dirs", map[string]string{})
 	v.SetDefault("up.match_domains_dns", []string{})

--- a/internal/config/const.go
+++ b/internal/config/const.go
@@ -1,0 +1,13 @@
+package config
+
+// ManagedBy identifies the package manager managing this binary (e.g., "nix", "brew", "apt").
+// Defaults to "none", indicating the CLI manages its own updates internally.
+//
+// This value can be overridden at build time using ldflags:
+//
+//	go build -ldflags "-X github.com/fosrl/cli/internal/config.ManagedBy=<manager>"
+var ManagedBy = "none"
+
+func IsExternallyManaged() bool {
+	return ManagedBy != "none"
+}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Add the `ManagedBy` build flag to let third-party package managers (e.g., Nix) inform the CLI of their presence.
When a package manager is used, the CLI defaults `disable_update_check = true`.

## How to Test

1. Build the CLI with `ManagedBy` set (e.g., `-ldflags "-X github.com/fosrl/cli/internal/config.ManagedBy=nix"`).
2. Run `pangolin config show` and see `disable_update_check` defaults to `true`.
