### PR TITLE
Bump flake.nix version to 0.15.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       in rec {
         pangolin-cli = pkgs.buildGoModule {
           pname = "pangolin-cli";
-          version = "0.13.0";
+          version = "0.15.1";
           src = ./.;
 
           vendorHash = "sha256-mb5IGRRz5pZoi7QJSNVRubQDfhRZu977CWq1Gf6Z7bQ=";


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The Nix package version in flake.nix was still 0.13.0, so a Nix install reported the wrong version. Bumped it to 0.15.1 to match the release.(The embedded Version constant in consts.go is already 0.15.1 in dev.)

## How to test?
run nix flake show and check if the new version appears


